### PR TITLE
Make MirrorList::Get function more readable.

### DIFF
--- a/src/api/mirrors.rs
+++ b/src/api/mirrors.rs
@@ -112,10 +112,9 @@ impl MirrorList {
     }
 
     pub fn get(&self, mirror_type: MirrorType, index: usize) -> Result<Mirror, &'static str> {
-        if let MirrorType::Search = mirror_type {
-            return Ok(self.search_mirrors.get(index).unwrap().clone());
-        } else {
-            return Ok(self.download_mirrors.get(index).unwrap().clone());
+        match mirror_type {
+            MirrorType::Search => Ok(self.search_mirrors.get(index).unwrap().clone()),
+            MirrorType::Download => Ok(self.download_mirrors.get(index).unwrap().clone()),
         }
     }
 }


### PR DESCRIPTION
Matching both possible states of the enum is more readable than implying MirrorType::Download with an else statement.